### PR TITLE
Adds API_MODE env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.6.3-alpine3.9
 
+ARG API_MODE=""
 ARG APP_NAME=app
 ARG RAILS_DATABASE_ENGINE=postgresql
 ARG RAILS_VERSION=5.2.3
@@ -9,7 +10,7 @@ ARG VIEW_ENGINE=react
 RUN apk add build-base=0.5-r1 \
 	mariadb-dev=10.3.15-r0 \
 	nodejs=10.14.2-r0 \
-	postgresql-dev=11.3-r0 \
+	postgresql-dev=11.4-r0 \
 	sqlite-dev=3.28.0-r0 \
 	tzdata=2019a-r0 \
 	yarn=1.12.3-r0 \
@@ -20,6 +21,7 @@ WORKDIR /srv
 
 RUN rails new $APP_NAME --database=$RAILS_DATABASE_ENGINE \
 	--webpack=$VIEW_ENGINE \
+	$API_MODE \
 	$SKIP_TEST_UNIT
 
 COPY . /srv/$APP_NAME/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: .
       args:
+        API_MODE: $API_MODE
         APP_NAME: $APP_NAME
         RAILS_DATABASE_ENGINE: $RAILS_DATABASE_ENGINE
         RAILS_VERSION: $RAILS_VERSION

--- a/example.env
+++ b/example.env
@@ -1,5 +1,6 @@
 # Copy this file to .env
 # Configure settings here to quickly build your Rails environment
+API_MODE=
 APP_NAME=app
 RAILS_DATABASE_ENGINE=postgresql
 RAILS_VERSION=5.2.3

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,8 @@ BOOTSTRAP_CONTAINER_VERSION=0.1.0
 
 build() {
     echo "Building initial image..."
-    docker build --build-arg APP_NAME=$APP_NAME \
+    docker build --build-arg API_MODE=$API_MODE \
+	    --build-arg APP_NAME=$APP_NAME \
 	    --build-arg RAILS_DATABASE_ENGINE=$RAILS_DATABASE_ENGINE \
 	    --build-arg RAILS_VERSION=$RAILS_VERSION \
 	    --build-arg SKIP_TEST_UNIT=$SKIP_TEST_UNIT \


### PR DESCRIPTION
This will be used as another method for passing an argument to the build
command when generating a new rails application. It should be either
left as empty string (the default) or set to `--api`.