### PR TITLE
Make webpack optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM ruby:2.6.3-alpine3.9
 
 ARG API_MODE=""
 ARG APP_NAME=app
-ARG RAILS_DATABASE_ENGINE=postgresql
+ARG RAILS_DATABASE_ENGINE="--database=postgresql"
 ARG RAILS_VERSION=5.2.3
 ARG SKIP_TEST_UNIT=""
-ARG VIEW_ENGINE=react
+ARG VIEW_ENGINE=""
 
 RUN apk add build-base=0.5-r1 \
 	mariadb-dev=10.3.15-r0 \
@@ -19,8 +19,8 @@ RUN apk add build-base=0.5-r1 \
 
 WORKDIR /srv
 
-RUN rails new $APP_NAME --database=$RAILS_DATABASE_ENGINE \
-	--webpack=$VIEW_ENGINE \
+RUN rails new $APP_NAME $RAILS_DATABASE_ENGINE \
+	$VIEW_ENGINE \
 	$API_MODE \
 	$SKIP_TEST_UNIT
 

--- a/example.env
+++ b/example.env
@@ -2,10 +2,10 @@
 # Configure settings here to quickly build your Rails environment
 API_MODE=
 APP_NAME=app
-RAILS_DATABASE_ENGINE=postgresql
+RAILS_DATABASE_ENGINE=--database=postgresql
 RAILS_VERSION=5.2.3
 SKIP_TEST_UNIT=
-VIEW_ENGINE=react
+VIEW_ENGINE=--webpack=react
 
 # MySQL example
 # APP_NAME=app


### PR DESCRIPTION
By default webpack will not be installed or configured instead of
defaulting to react. This allows Rails to be generated in API mode
without also installing all the webpack view cruft.